### PR TITLE
change depricated np.float to float

### DIFF
--- a/src/ros_numpy/point_cloud2.py
+++ b/src/ros_numpy/point_cloud2.py
@@ -221,7 +221,7 @@ def split_rgb_field(cloud_arr):
             new_cloud_arr[field_name] = cloud_arr[field_name]
     return new_cloud_arr
 
-def get_xyz_points(cloud_array, remove_nans=True, dtype=np.float):
+def get_xyz_points(cloud_array, remove_nans=True, dtype=float):
     '''Pulls out x, y, and z columns from the cloud recordarray, and returns
 	a 3xN matrix.
     '''


### PR DESCRIPTION
Since numpy 1.24, `np.float` now throws an error. Here I replace the 1 instance of `np.float` with `float`.